### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,18 +21,18 @@ path = "src/main.rs"
 [dependencies]
 pidgin = "0.4"
 clap = "2.34"
-larry = "0"
+larry = "0.3"
 regex = "1"
 flate2 = "1"
-rust-ini = "0"
+rust-ini = "0.18"
 dirs = "4"
-chrono = "0"
+chrono = "0.4"
 colonnade = { version = "^1.3", features=["nbsp"] }
-term_size = "0"
+term_size = "0.3"
 lazy_static = "1.4"
-ansi_term = "0"
+ansi_term = "0.12"
 serde_json = "1"
 two_timer = { version="^2.1", features=["small_grammar"] }
 
 [dev-dependencies]
-rand = "0"
+rand = "0.8"


### PR DESCRIPTION
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.